### PR TITLE
Enabled notifications that are sent to user every hour.

### DIFF
--- a/app/src/main/java/app/solocoin/solocoin/app/SharedPrefs.kt
+++ b/app/src/main/java/app/solocoin/solocoin/app/SharedPrefs.kt
@@ -113,6 +113,22 @@ class SharedPrefs(context: Context) {
         get() = instance.getBoolean(_mock, false)
         set(value) = instance.edit().putBoolean(_mock, value).apply()
 
+    private val _recent_notif_time = "recent_notif_time"
+    var recentNotifTime: Long
+        get() = instance.getLong(_recent_notif_time, 0)
+        set(value) = instance.edit().putLong(_recent_notif_time, value).apply()
+
+    private val _recent_check_time = "recent_check_time"
+    var recentCheckTime: Long
+        get() = instance.getLong(_recent_check_time, 0)
+        set(value) = instance.edit().putLong(_recent_check_time, value).apply()
+
+    private val _period_valid = "period_valid"
+    var periodValid: Boolean
+        get() = instance.getBoolean(_period_valid, false)
+        set(value) = instance.edit().putBoolean(_period_valid, value).apply()
+
+
 //    private val _loggedin = "loggedin"
 //    var loggedIn: Boolean
 //        get() = instance.getBoolean(_loggedin, false)

--- a/app/src/main/java/app/solocoin/solocoin/worker/NotificationPingWorker.kt
+++ b/app/src/main/java/app/solocoin/solocoin/worker/NotificationPingWorker.kt
@@ -1,0 +1,97 @@
+package app.solocoin.solocoin.worker
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.util.Log
+import androidx.core.app.NotificationCompat
+import androidx.work.Worker
+import androidx.work.WorkerParameters
+import app.solocoin.solocoin.R
+import app.solocoin.solocoin.app.SolocoinApp
+import app.solocoin.solocoin.app.SolocoinApp.Companion.sharedPrefs
+import app.solocoin.solocoin.model.SessionPingRequest
+import app.solocoin.solocoin.repo.SolocoinRepository
+import app.solocoin.solocoin.ui.home.HomeActivity
+import app.solocoin.solocoin.util.GlobalUtils
+import com.google.gson.JsonObject
+import com.google.gson.JsonParser
+import kotlinx.android.synthetic.main.activity_login_signup.view.*
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.InternalCoroutinesApi
+import org.koin.core.KoinComponent
+import org.koin.core.inject
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.Response
+import java.sql.Time
+import java.util.*
+
+// author: Vijay Daita
+
+// Gives notification ping
+
+@InternalCoroutinesApi
+@ExperimentalCoroutinesApi
+class NotificationPingWorker(appContext: Context, workerParams: WorkerParameters) :
+    Worker(appContext, workerParams), KoinComponent {
+
+    private val repository: SolocoinRepository by inject()
+    private val notificationID = 402;
+
+    override fun doWork(): Result {
+        return doApiCall()
+    }
+
+    private fun doApiCall(): Result {
+        Log.d(API_CALL, "Creating Notification")
+        val builder = NotificationCompat.Builder(applicationContext)
+        builder.setSmallIcon(R.drawable.app_icon)
+        builder.setContentTitle(applicationContext.getString(R.string.notif_checkin))
+        builder.setContentText(applicationContext.getString(R.string.notif_checkin_desc))
+
+        val regIntent = Intent(applicationContext, HomeActivity.javaClass)
+        regIntent.putExtra("from_checkin", true)
+        val pendingIntent = PendingIntent.getActivity(applicationContext, notificationID, regIntent, 0)
+
+        builder.setContentIntent(pendingIntent)
+
+        val notificationManager: NotificationManager =
+            applicationContext.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val importance = NotificationManager.IMPORTANCE_HIGH
+            val channel = NotificationChannel("2", "Solocoin Check-in", importance).apply {
+                description = "Solocoin Check-in"
+            }
+            // Register the channel with the system
+            notificationManager.createNotificationChannel(channel)
+        }
+
+        notificationManager.notify(notificationID, builder.build())
+
+        sharedPrefs?.let{
+            val time = Calendar.getInstance().get(Calendar.MILLISECOND)
+            it.recentNotifTime = time.toLong()
+        }
+
+        return Result.success()
+    }
+
+    override fun onStopped() {
+        Log.wtf(TAG, "Stopping Notification Worker")
+        super.onStopped()
+    }
+
+    companion object {
+        private val TAG: String? = SessionPingWorker::class.java.simpleName
+        private val API_CALL: String = SessionPingWorker::class.java.simpleName + " API_CALL"
+//        /*
+//         * Avoid notification for fused location service start on first time user open home activity
+//         */
+//        @JvmStatic private var firstTime: Boolean = true
+    }
+}

--- a/app/src/main/java/app/solocoin/solocoin/worker/SessionPingWorker.kt
+++ b/app/src/main/java/app/solocoin/solocoin/worker/SessionPingWorker.kt
@@ -17,6 +17,7 @@ import org.koin.core.inject
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
+import java.util.*
 
 /**
  * Created by Saurav Gupta on 07/05/20
@@ -35,6 +36,14 @@ class SessionPingWorker(appContext: Context, workerParams: WorkerParameters) :
      */
     override fun doWork(): Result {
         //Log.d(TAG, "Initiating the work")
+
+        // Checking if the period is valid
+        sharedPrefs?.let{
+            if((it.recentNotifTime + 30*60*1000 <= Calendar.getInstance().get(
+                    Calendar.MILLISECOND).toLong()) && it.recentCheckTime < it.recentNotifTime){
+                it.periodValid = false
+            }
+        }
 
 //        /*
 //         * Checking if fused location service is running.

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -87,6 +87,9 @@
 
     <string name="start_time">0h 0m 0s</string>
 
+    <string name="notif_checkin">Solocoin Notification Check-in</string>
+    <string name="notif_checkin_desc">Please click on the notification for us to ensure you are still here.</string>
+
     //rewards + wallet section
     <string name="claim_offer">CLAIM OFFER</string>
     <string name="claim_error">Sorry, an error occurred. Please contact customer support.</string>


### PR DESCRIPTION
 If the user clicks on the notification within 30 minutes, periodCheck is updated in the SharedPrefs and if a ping happens before a click, SessionPingWorker makees an extra check. Use periodCheck as wanted to be able to ensure that the user is active. Checks before sending have not been enabled.

Said push will come in the next commit.
